### PR TITLE
Changed max transactions to 50 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Changed max transactions to 50 by default](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/22)
+
 ## [[1.0.0](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/21)] - 2024-08-29
 - [Upgrade sdk-dapp-utils, sdk-dapp-core and cross-window-provider - breaking changes](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/20)
 

--- a/src/hooks/helpers/sign.ts
+++ b/src/hooks/helpers/sign.ts
@@ -10,7 +10,7 @@ const isExtension = ['moz-extension:', 'chrome-extension:'].includes(
   safeWindow?.location?.protocol ?? ""
 );
 
-const maxTransactions = safeWindow?.opener || isExtension ? 50 : 5;
+const maxTransactions = 50;
 
 const validString = mixed().test(
   'string',


### PR DESCRIPTION
### Issue
Cannot sign transactions with sdk-dapp when there are more than 5 transactions.

### Reproduce
Sign 6 transactions from web wallet hub in xexchange (e.g. claim rewards). The sign modal does not show.

### Root cause
Maximum of 5 transactions are allowed due to the limitations of URL lengths

### Fix
Set the max transactons variable to 50 by default.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
