### PR TITLE
Added custom domain functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[1.1.3](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/34)] - 2024-11-15
+- [Added custom domain functionality](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/33)
+
 ## [[1.1.2](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/32)] - 2024-10-28
 - [Fixed parsing more than 20 transactions](https://github.com/multiversx/mx-sdk-js-web-wallet-io/pull/31)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-js-web-wallet-io",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": false,
   "main": "out/index.js",
   "types": "out/index.d.ts",

--- a/src/hooks/helpers/getDomain.ts
+++ b/src/hooks/helpers/getDomain.ts
@@ -1,0 +1,24 @@
+import { isFirefox, isSafari } from 'helpers';
+import { extractDomain } from './extractDomain';
+
+let customDomain = '';
+
+export const setCustomDomain = (domain: string) => {
+  customDomain = domain;
+};
+
+export const getDomain = (urlDomain: string | null) => {
+  if (customDomain) {
+    const domain = customDomain;
+    setCustomDomain('');
+    return domain;
+  }
+
+  let domain = isFirefox() || isSafari() ? urlDomain : '';
+
+  if (document.referrer) {
+    domain = extractDomain(document.referrer).domain;
+  }
+
+  return domain;
+};

--- a/src/hooks/helpers/validUrlSchema/getIsValidUrl.ts
+++ b/src/hooks/helpers/validUrlSchema/getIsValidUrl.ts
@@ -3,6 +3,7 @@ import { isFirefox, isSafari } from 'helpers';
 import { decodeAndSanitizeUrl } from 'helpers/navigation/decodeAndSanitizeUrl';
 import { extractDomain } from '../extractDomain';
 import { getNativeAuthTokenDomain } from '../getNativeAuthTokenDomain';
+import { getDomain } from '../getDomain';
 
 export const getIsValidUrl = ({
   value,
@@ -25,20 +26,16 @@ export const getIsValidUrl = ({
   }
 
   const { domain: urlDomain } = extractDomain(url);
-  let comparedDomain = isFirefox() || isSafari() ? urlDomain : '';
+  const domain = getDomain(urlDomain);
 
-  if (document.referrer) {
-    comparedDomain = extractDomain(document.referrer).domain;
-  }
-
-  // use nativeAuthOrigin if defined. If not, fallback on comparedDomain
+  // use nativeAuthOrigin if defined. If not, fallback on domain
   const nativeAuthTokenDomain = getNativeAuthTokenDomain({
     token,
-    fallbackDomain: comparedDomain
+    fallbackDomain: domain
   });
 
   const sameDomainAsReferrer =
-    comparedDomain === urlDomain && comparedDomain === nativeAuthTokenDomain;
+    domain === urlDomain && domain === nativeAuthTokenDomain;
 
   const isTestEnvironment = urlDomain?.endsWith('.localhost');
 


### PR DESCRIPTION
### Issue
When signing a nativeAuth token for web wallet internal use while being connected to another dApp, the URL domain used for sign-message validation needs to be the same as the one in the new local nativeAuth token

### Root cause
Document.referrer (validation domain) was pointing to the connected dApp

### Fix
Allow on-demand change of validation domain with `setCustomDomain` helper

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
